### PR TITLE
E2E: turn off db container after test

### DIFF
--- a/e2e/e2e.spec.js
+++ b/e2e/e2e.spec.js
@@ -1,49 +1,54 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect, afterAll, describe, beforeAll } = require('@playwright/test');
+const { execSync } = require('child_process');
 
-test('homepage loads and has the correct title', async ({ page }) => {
-  await page.goto('http://localhost:5173');
-  const locator = await page.getByText('Phonebook');
-  await expect(locator).toBeVisible();
-});
-
-test('Phonebook entries can be created, modified and deleted', async ({ page }) => {
-  await page.goto('http://localhost:5173');
-
-  await page.getByLabel('Name:').click();
-  await page.getByLabel('Name:').fill('Test');
-  await page.getByLabel('Phone:').click();
-  await page.getByLabel('Phone:').fill('12345');
-  await page.getByTestId('submit-button').click();
-
-  const addedPersonName = await page.getByText('Test');
-  await expect(addedPersonName).toBeVisible();
-  const addedPersonNumber = await page.getByText('12345');
-  await expect(addedPersonNumber).toBeVisible();
-
-  await page.getByRole('button', { name: 'update' }).last().click();
-  await page.getByTestId('name-input').click();
-  await page.getByTestId('name-input').fill('Test2');
-  await page.getByTestId('number-input').click();
-  await page.getByTestId('number-input').fill('111111');
-  await page
-    .locator('div')
-    .filter({ hasText: /^Update entryName:Phone:Submit$/ })
-    .getByRole('button')
-    .click();
-
-  const updatedName = await page.getByText('Test2');
-  await expect(updatedName).toBeVisible();
-  const updatedNumber = await page.getByText('111111');
-  await expect(updatedNumber).toBeVisible();
-
-  page.on('dialog', async (dialog) => {
-    console.log(dialog.message());
-    await dialog.accept();
+describe('E2E tests', () => {
+  test('homepage loads and has the correct title', async ({ page }) => {
+    await page.goto('http://localhost:5173');
+    const locator = await page.getByText('Phonebook');
+    await expect(locator).toBeVisible();
   });
 
-  await page.getByRole('button', { name: 'delete' }).last().click();
-  await page.waitForTimeout(2000);
+  test('Phonebook entries can be created, modified and deleted', async ({ page }) => {
+    await page.goto('http://localhost:5173');
 
-  await expect(updatedName).not.toBeVisible();
-  await expect(updatedNumber).not.toBeVisible();
+    await page.getByLabel('Name:').click();
+    await page.getByLabel('Name:').fill('Test');
+    await page.getByLabel('Phone:').click();
+    await page.getByLabel('Phone:').fill('12345');
+    await page.getByTestId('submit-button').click();
+
+    const addedPersonName = await page.getByText('Test');
+    await expect(addedPersonName).toBeVisible();
+    const addedPersonNumber = await page.getByText('12345');
+    await expect(addedPersonNumber).toBeVisible();
+
+    await page.getByRole('button', { name: 'update' }).last().click();
+    await page.getByTestId('name-input').click();
+    await page.getByTestId('name-input').fill('Test2');
+    await page.getByTestId('number-input').click();
+    await page.getByTestId('number-input').fill('111111');
+    await page
+      .locator('div')
+      .filter({ hasText: /^Update entryName:Phone:Submit$/ })
+      .getByRole('button')
+      .click();
+
+    const updatedName = await page.getByText('Test2');
+    await expect(updatedName).toBeVisible();
+    const updatedNumber = await page.getByText('111111');
+    await expect(updatedNumber).toBeVisible();
+
+    page.on('dialog', async (dialog) => {
+      console.log(dialog.message());
+      await dialog.accept();
+    });
+
+    await page.getByRole('button', { name: 'delete' }).last().click();
+    await page.waitForTimeout(2000);
+
+    await expect(updatedName).not.toBeVisible();
+    await expect(updatedNumber).not.toBeVisible();
+
+    execSync('docker-compose -f db/docker-compose.test.yaml down', { stdio: 'inherit' });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "child_process": "^1.0.2"
+      },
       "devDependencies": {
         "@playwright/test": "^1.45.3",
         "@types/node": "^20.14.12",
@@ -98,6 +101,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g=="
     },
     "node_modules/cliui": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "start:all:test": "concurrently \"npm run start:test-db\" \"npm run start:backend\" \"npm run start:frontend\"",
     "start:all:dev": "concurrently \"npm run start:dev-db\" \"npm run start:backend\" \"npm run start:frontend\"",
     "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "child_process": "^1.0.2"
   }
 }


### PR DESCRIPTION
Aim is to turn off the database container after E2E tests, otherwise it needs to be done manually